### PR TITLE
Only consider published articled in feed.

### DIFF
--- a/src/outpost/django/feed/conf.py
+++ b/src/outpost/django/feed/conf.py
@@ -4,7 +4,6 @@ from django.conf import settings
 
 class FeedAppConf(AppConf):
     CACHE_IMAGE_TIMEOUT = 3600
-    ARTICLE_ROLES = []
     ARTICLE_DESCRIPTION = ""
     ARTICLE_COPYRIGHT = ""
     ARTICLE_URL = ""

--- a/src/outpost/django/feed/feeds.py
+++ b/src/outpost/django/feed/feeds.py
@@ -42,8 +42,8 @@ class ArticleFeed(FeedCache, Feed):
     def get_object(self, request, pk):
         return models.Consumer.objects.get(pk=pk)
 
-    def items(self, obj):
-        return models.Article.objects.filter(roles__overlap=obj.roles).order_by(
+    def items(self):
+        return models.Article.objects.filter(published__isnull=False).order_by(
             "-published"
         )[: settings.FEED_ARTICLE_ITEMS]
 

--- a/src/outpost/django/feed/views.py
+++ b/src/outpost/django/feed/views.py
@@ -78,6 +78,8 @@ class ReceiverView(APIView):
     def synchronize(self, model, data):
         defaults = dict()
         entry = data.get("entry", {})
+        if not entry.get("publishedAt"):
+            return HttpResponse("Entry not published yet", status=400)
         for field in model._meta.fields:
             if hasattr(model, "Mapping") and (
                 converter := getattr(model.Mapping, field.attname, None)


### PR DESCRIPTION
Filters articles and only uses the ones  whose publication date is not `null` (meaning they are published), does not allow access to unpublished articles (if they do not have a publication date) and removes unused config