### PR TITLE
Synchronize only articles with the export flag set.

### DIFF
--- a/src/outpost/django/feed/views.py
+++ b/src/outpost/django/feed/views.py
@@ -80,6 +80,8 @@ class ReceiverView(APIView):
         entry = data.get("entry", {})
         if not entry.get("publishedAt"):
             return HttpResponseBadRequest(_("Entry not published yet"))
+        if not entry.get("exportToStudo", False):
+            return HttpResponseBadRequest(_("Entry not eligible for export"))
         for field in model._meta.fields:
             if hasattr(model, "Mapping") and (
                 converter := getattr(model.Mapping, field.attname, None)


### PR DESCRIPTION
The flag should now be populated by Muniverse/Strapi and OE Öffentlichkeitsarbeit requested to only consider articles with this flag enabled to be stored for the feed.